### PR TITLE
Updated to v2.0.1.  Use latest Jenkins dependencies. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 .idea
+.vscode
 
 # CMake
 cmake-build-debug/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Jenkins plugin to upload builds to zScan for analysis.
 ## Pre-requisites
 
 This project requires Java 11 or higher to build. All of the 3rd-party jars we're using are compiled with Java 17.  
-Java 8 has reached EOL; LTS for Java 11 ended around September/November 2023. We should be using Java 17 or later.
-For backward-compatibility, Java 11 works for now. 
-
 
 In your console, head over to the Authorizations tab in the Manage section and generate a new API key that at least has the scope to `upload z3a_builds`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <!-- See https://github.com/jenkinsci/plugin-pom/releases for available versions -->
-        <version>4.82</version>
+        <version>4.86</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>zScanJenkinsUploadPlugin</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <packaging>hpi</packaging>
     <properties>
         <!--
@@ -61,7 +61,7 @@
             The 2.xxx.3 are typically the last releases of a given line
             2.387.2 is the oldest LTS currently supported by the Jenkins update center.
         -->
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.440.3</jenkins.version>
     </properties>
     <name>Upload to zScan Plugin</name>
     <description>This plugin uploads build artifacts to zScan for app analysis</description>

--- a/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevUploadPlugin.java
+++ b/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/ZDevUploadPlugin.java
@@ -26,7 +26,6 @@ import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -54,7 +53,7 @@ public class ZDevUploadPlugin extends Recorder implements SimpleBuildStep{
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
         final PrintStream console = listener.getLogger();
 
         if (Result.ABORTED.equals(run.getResult())) {
@@ -105,6 +104,7 @@ public class ZDevUploadPlugin extends Recorder implements SimpleBuildStep{
                     return;
                 }
 
+                @SuppressWarnings("null") // there's a null check above
                 String accessToken = response.body().getAccessToken();
                 String authToken = "Bearer " + accessToken;
 
@@ -157,6 +157,7 @@ public class ZDevUploadPlugin extends Recorder implements SimpleBuildStep{
             load();
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;

--- a/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/dtos/LoginCredentials.java
+++ b/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/dtos/LoginCredentials.java
@@ -1,7 +1,9 @@
 package com.zimperium.plugins.zDevJenkinsUploadPlugin.dtos;
 
 public class LoginCredentials {
+    @SuppressWarnings("unused")
     private final String clientId;
+    @SuppressWarnings("unused")
     private final String secret;
 
     public LoginCredentials(String clientId, String secret) {

--- a/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/dtos/RefreshCredentials.java
+++ b/src/main/java/com/zimperium/plugins/zDevJenkinsUploadPlugin/dtos/RefreshCredentials.java
@@ -1,6 +1,7 @@
 package com.zimperium.plugins.zDevJenkinsUploadPlugin.dtos;
 
 public class RefreshCredentials {
+    @SuppressWarnings("unused")
     private final String refreshToken;
 
     public RefreshCredentials(String refreshToken) {


### PR DESCRIPTION
Minimum Jenkins version is 2.440.3 (April 2024). Per [developer guide](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions):

Currently recommended versions
At the moment, the Jenkins releases 2.440.3 and 2.452.4 make good core dependencies. You could also consider 2.462.1 if there are specific reasons, like new features, to want something newer. 